### PR TITLE
Modernize API 

### DIFF
--- a/examples/browser/main.js
+++ b/examples/browser/main.js
@@ -52,9 +52,9 @@ class LoginExtent extends bg.Extent {
             let email = extent.email.value;
             let emailValid = validateEmail(email);
             extent.emailValid.update(emailValid);
-            extent.sideEffect(null, (extent) => {
+            extent.sideEffect((extent) => {
                 inputFeedback("emailFeedback", extent.emailValid.value);
-            });
+            }, undefined, null);
 
         });
 
@@ -64,9 +64,9 @@ class LoginExtent extends bg.Extent {
             let password = extent.password.value ?? "";
             let passwordValid = password.length > 0;
             extent.passwordValid.update(passwordValid);
-            extent.sideEffect("passwordFeedback", (extent) => {
+            extent.sideEffect((extent) => {
                 inputFeedback("passwordFeedback", extent.passwordValid.value);
-            });
+            }, undefined, "passwordFeedback");
 
         });
 
@@ -75,9 +75,9 @@ class LoginExtent extends bg.Extent {
 
             let enabled = extent.emailValid.value && extent.passwordValid.value && !extent.loggingIn.value;
             extent.loginEnabled.update(enabled)
-            extent.sideEffect("enable login button", (extent) => {
+            extent.sideEffect((extent) => {
                 loginButtonEnable(extent.loginEnabled.value);
-            });
+            }, undefined, "enable login button");
 
         });
 
@@ -91,16 +91,16 @@ class LoginExtent extends bg.Extent {
             }
 
             if (extent.loggingIn.justUpdatedTo(true)) {
-                extent.sideEffect("login api call", (extent) => {
+                extent.sideEffect((extent) => {
                     loginToServer(extent.email.value, extent.password.value);
-                });
+                }, undefined, "login api call");
             }
 
         });
 
 
         this.makeBehavior([this.loggingIn, this.loginComplete, this.addedToGraph], null, (extent) => {
-            extent.sideEffect("login status", (extent) => {
+            extent.sideEffect((extent) => {
                 let status = "&nbsp;"
                 if (extent.loggingIn.value) {
                     status = "Logging in...";
@@ -112,7 +112,7 @@ class LoginExtent extends bg.Extent {
                     }
                 }
                 updateLoginStatus(status);
-            });
+            }, undefined, "login status");
         });
 
     }

--- a/src/__tests__/bggraph.test.ts
+++ b/src/__tests__/bggraph.test.ts
@@ -1177,6 +1177,30 @@ describe('dynamic graph changes', () => {
             });
         });
     });
+
+    test('updating demands on behavior that has already run will affect future events', () => {
+        // |> Given a behavior that demands one resource
+        let m1 = ext.moment();
+        let m2 = ext.moment();
+        let run = false;
+        ext.behavior([m1], null, ext1 => {
+            ext1.graph.currentBehavior!.setDynamicDemands([m2]);
+            run = true;
+        });
+        ext.addToGraphWithAction();
+
+        // It doesn't activate on other resource
+        m2.updateWithAction();
+        expect(run).toBeFalsy();
+
+        // |> When behavior updates demands on itself to include m2
+        m1.updateWithAction();
+        run = false;
+
+        // |> Then m2 updating will activate the behavior
+        m2.updateWithAction();
+        expect(run).toBeTruthy();
+    });
 });
 
 
@@ -1190,7 +1214,7 @@ describe('Extents', () => {
 
         constructor(graph: Graph) {
             super(graph);
-            this.r1 = this.state(0, 'r1');
+            this.r1 = this.state(0);
             this.r2 = this.state(0, 'custom_r2');
             this.b1 = this.behavior([this.r1], [this.r2], (extent: TestExtent) => {
                 if (this.r1.justUpdated) {
@@ -1206,25 +1230,8 @@ describe('Extents', () => {
 
     test('gets class name', () => {
         let e = new TestExtent(g);
-        let m1 = e.moment()
-        let m2 = e.moment()
-        let m3 = e.moment()
 
         expect(e.debugConstructorName).toBe('TestExtent');
-
-        e.behavior().demands(m1, m2).supplies(m3).runs(ext1 => {
-
-        });
-
-
-        e.behavior()
-            .dynamicDemands([m2], ext1 => {
-                return []
-            })
-            .runs(ext1 => {
-                m3.update();
-            });
-
     })
 
     test('contained components picked up', () => {

--- a/src/__tests__/bggraph.test.ts
+++ b/src/__tests__/bggraph.test.ts
@@ -82,7 +82,7 @@ describe('State Resource', () => {
 
         // |> When updated with same value and filtering off
         let entered = sr1.event;
-        g.action(null, () => {
+        g.action(() => {
             sr1.updateForce(1);
         })
 
@@ -116,7 +116,7 @@ describe('State Resource', () => {
         ext.addToGraphWithAction();
 
         // |> When updated in push event
-        ext.action('update', () => {
+        ext.action(() => {
             sr1.update(1);
         });
 
@@ -206,10 +206,10 @@ describe('State Resource', () => {
         // |> When it is updated multiple times in action (or behavior)
         var traceValue;
         var traceEvent;
-        g.action(null, () => {
+        g.action(() => {
             sr1.update(1);
             sr1.update(2);
-            g.sideEffect(ext, null, (extent) => {
+            g.sideEffect(() => {
                 traceValue = sr1.traceValue;
                 traceEvent = sr1.traceEvent;
             });
@@ -244,7 +244,7 @@ describe('State Resource', () => {
             didRun = true;
         });
 
-        g.action('adding', () => {
+        g.action(() => {
             sr1.update(1);
             ext.addToGraph();
         });
@@ -354,7 +354,7 @@ describe('Moment Resource', () => {
         // |> When it is read in the graph (and was not updated)
         let beforeUpdate = false;
         let happenedEvent = null;
-        ext.action('initial', () => {
+        ext.action(() => {
             beforeUpdate = mr1.justUpdated;
             mr1.update();
             happenedEvent = ext.graph.currentEvent;
@@ -401,7 +401,7 @@ describe('Moment Resource', () => {
             didRun = true;
         });
 
-        g.action('adding', () => {
+        g.action(() => {
             mr1.update();
             ext.addToGraph();
         });
@@ -490,7 +490,7 @@ describe('dependencies', () => {
 
         ext.addToGraphWithAction();
 
-        g.action('test', () => {
+        g.action(() => {
             r_a.update(1);
             r_b.update(2);
         });
@@ -530,7 +530,7 @@ describe('dependencies', () => {
         ext2.addToGraphWithAction();
         parentExt.addToGraphWithAction()
 
-        g.action('update ext2_r1', () => {
+        g.action(() => {
             ext2_r1.update(33)
         });
 
@@ -548,7 +548,7 @@ describe('dynamic graph changes', () => {
             r_x.update(r_a.value * 2);
         });
 
-        g.action('add', () => {
+        g.action(() => {
             r_a.update(2);
             ext.addToGraph();
         });
@@ -647,7 +647,7 @@ describe('dynamic graph changes', () => {
         });
         let ext2behavior = ext2.behavior([demanded1], null, extent => {
         });
-        g.action("adding", () => {
+        g.action(() => {
             ext.addToGraph();
             ext2.addToGraph();
         });
@@ -672,7 +672,7 @@ describe('dynamic graph changes', () => {
         });
         let ext2behavior = ext2.behavior(null, [supplied2], extent => {
         });
-        g.action("adding", () => {
+        g.action(() => {
             ext.addToGraph();
             ext2.addToGraph();
         });
@@ -694,7 +694,7 @@ describe('dynamic graph changes', () => {
         let demanded2 = ext2.moment('demanded2');
         let ext2behavior = ext2.behavior([demanded1, demanded2], null, extent => {
         });
-        g.action('adding', () => {
+        g.action(() => {
             ext.addToGraph();
             ext2.addToGraph();
         });
@@ -717,7 +717,7 @@ describe('dynamic graph changes', () => {
         let supplied2 = ext2.moment('supplied2');
         let ext2behavior = ext2.behavior(null, [supplied1, supplied2], extent => {
         });
-        g.action('adding', () => {
+        g.action(() => {
             ext.addToGraph();
             ext2.addToGraph();
         });
@@ -748,9 +748,9 @@ describe('dynamic graph changes', () => {
             ext2.removeFromGraph();
         });
 
-        g.action('add', () => {
-            ext.addToGraphWithAction();
-            ext2.addToGraphWithAction();
+        g.action(() => {
+            ext.addToGraph();
+            ext2.addToGraph();
         });
 
         // when it is both activated and removed in the same event
@@ -787,7 +787,7 @@ describe('dynamic graph changes', () => {
         });
         ext.addToGraphWithAction();
 
-        g.action('update', () => {
+        g.action(() => {
             b1.setDemands([r_a]);
         });
 
@@ -817,7 +817,7 @@ describe('dynamic graph changes', () => {
         });
         ext.addToGraphWithAction();
 
-        g.action('update', () => {
+        g.action(() => {
             b1.setSupplies([r_a]);
         });
 
@@ -845,7 +845,7 @@ describe('dynamic graph changes', () => {
         ext2.addToGraphWithAction();
 
         // update the supply to accommodate
-        g.action('supply r_x', () => {
+        g.action(() => {
             b_b.setSupplies([r_x]);
         });
 
@@ -867,7 +867,7 @@ describe('dynamic graph changes', () => {
         ext.addToGraphWithAction();
 
         // |> When that behavior no longer supplies that original resource
-        ext.action("change supply", () => {
+        ext.action(() => {
             m1.suppliedBy!.setSupplies([]);
         });
 
@@ -902,7 +902,7 @@ describe('Extents', () => {
 
     test('gets class name', () => {
         let e = new TestExtent(g);
-        expect(e.debugName).toBe('TestExtent');
+        expect(e.debugConstructorName).toBe('TestExtent');
     });
 
     test('contained components picked up', () => {
@@ -933,7 +933,7 @@ describe('Extents', () => {
     test('added resource is updated on adding', () => {
         let e = new Extent(g);
         let runOnAdd = false;
-        e.behavior([e.addedToGraph], [], extent => {
+        e.behavior([e.added], [], extent => {
             runOnAdd = true;
         });
         e.addToGraphWithAction();
@@ -952,11 +952,11 @@ describe('Extents', () => {
         test('check actions on unadded extents are errors', () => {
             let e = new TestExtent(g);
             expect(() => {
-                e.action('impulse1', () => {
+                e.action(() => {
                 });
             }).toThrow();
             expect(() => {
-                e.actionAsync('impulse2', () => {
+                e.actionAsync(() => {
                 });
             }).toThrow();
         });
@@ -1050,13 +1050,13 @@ describe('Graph checks', () => {
         });
 
         expect(() => {
-            g.action('update', () => {
+            g.action(() => {
                 b_x.setDemands([r_a]);
             });
         }).toThrow();
 
         expect(() => {
-            g.action('update', () => {
+            g.action(() => {
                 b_x.setSupplies([r_a]);
             });
         }).toThrow();
@@ -1070,23 +1070,23 @@ describe('Graph checks', () => {
         let secondAction = false;
         ext.addToGraphWithAction();
         expect(() => {
-            g.action('throws', () => {
-                ext.sideEffect('action', (extent) => {
-                    g.action('innerAction', () => {
+            g.action(() => {
+                ext.sideEffect((extent) => {
+                    g.action(() => {
                         innerAction = true;
                     });
-                })
-                ext.sideEffect('innerEffect', (extent) => {
+                }, 'action')
+                ext.sideEffect((extent) => {
                     throw(new Error());
-                });
-                ext.sideEffect('effect', (extent) => {
+                }, 'innerEffect');
+                ext.sideEffect((extent) => {
                     innerEffect = true;
-                });
+                }, 'effect');
             });
         }).toThrow();
 
         // |> When trying to run another event
-        g.action('works', () => {
+        g.action(() => {
             secondAction = true;
         });
 
@@ -1117,7 +1117,7 @@ describe('Graph checks', () => {
         });
         ext.addToGraphWithAction();
         expect(() => {
-            g.action('r1', () => {
+            g.action(() => {
                 r1.update();
             });
         }).toThrow();
@@ -1138,7 +1138,7 @@ describe('Graph checks', () => {
 
         // |> When it throws when adding
         expect(() => {
-            g.action('add', () => {
+            g.action(() => {
                 ext.addToGraph();
                 throw(new Error());
             });
@@ -1167,9 +1167,9 @@ describe('Effects, Actions, Events', () => {
         let happened: boolean = false;
         // behavior a has a side effect and
         ext.behavior([r_a], [r_b], extent => {
-            extent.sideEffect('happen', extent => {
+            extent.sideEffect(extent => {
                 happened = true;
-            });
+            }, 'happen');
             r_b.update(1);
         });
 
@@ -1177,9 +1177,9 @@ describe('Effects, Actions, Events', () => {
         // check that side effect didn't happen during b's run
         ext.behavior([r_b], null, extent => {
             expect(happened).toBeFalsy();
-            extent.sideEffect('after effect', (extent) => {
+            extent.sideEffect((extent) => {
                 expect(happened).toBeTruthy();
-            });
+            }, 'after effect');
         });
 
         ext.addToGraphWithAction();
@@ -1194,17 +1194,17 @@ describe('Effects, Actions, Events', () => {
         let whenX: number = 0;
         let whenY: number = 0;
         ext.behavior([r_a], [r_b], extent => {
-            ext.sideEffect('first', (extent) => {
+            ext.sideEffect((extent) => {
                 whenX = counter;
                 counter += 1;
-            });
+            }, 'first');
             r_b.update(1);
         });
         ext.behavior([r_b], null, extent => {
-            ext.sideEffect('second', (extent) => {
+            ext.sideEffect((extent) => {
                 whenY = counter;
                 counter += 1;
-            });
+            }, 'second');
         });
 
         ext.addToGraphWithAction();
@@ -1217,10 +1217,10 @@ describe('Effects, Actions, Events', () => {
         let r1 = ext.moment('r1');
         ext.behavior([r_a], [r1], extent => {
             r1.update();
-            extent.sideEffect('after', (extent) => {
+            extent.sideEffect((extent) => {
                 expect(r_a.justUpdatedTo(1)).toBeTruthy();
                 expect(r1.justUpdated).toBeTruthy();
-            });
+            }, 'after');
         });
         ext.addToGraphWithAction();
         r_a.updateWithAction(1);
@@ -1239,7 +1239,7 @@ describe('Effects, Actions, Events', () => {
         ext.makeBehavior([r_a], null, (extent) => {
             if (r_a.justUpdated) {
                 extent.sideEffect('update b', (extent) => {
-                    ext.action('update b', () => {
+                    ext.action(() => {
                         // initiate another event
                         r_b.update(2)
                     });
@@ -1279,14 +1279,14 @@ describe('Effects, Actions, Events', () => {
         let m1 = ext.moment('m1');
         let eventLoopOrder, effect2Order: number | undefined;
         ext.behavior([m1], null, (extent) => {
-            extent.sideEffect('effect 1', (extent) => {
-                extent.graph.action('event2', () => {
+            extent.sideEffect((extent) => {
+                extent.graph.action(() => {
                     eventLoopOrder = effectCounter++;
                 });
-            });
-            extent.sideEffect('effect 2', (extent) => {
+            }, 'effect 1');
+            extent.sideEffect((extent) => {
                 effect2Order = effectCounter++;
-            });
+            }, 'effect 2');
         });
         ext.addToGraphWithAction();
 
@@ -1298,6 +1298,9 @@ describe('Effects, Actions, Events', () => {
         expect(eventLoopOrder).toEqual(1);
     });
 
+    /*
+    11/15/2021-- Actions created directly from within a behavior seem closer to a mistake
+    even if they could be rewritten as sideEffects. They are now disallowed.
     test('behaviors from first event complete before next event', () => {
         // Note: Initiating side effects directly from within a behavior can lead to accessing
         // and thus depending on state without being explicit about that dependency. However
@@ -1311,7 +1314,7 @@ describe('Effects, Actions, Events', () => {
         let m2 = ext.moment('m2');
         ext.behavior([m1], [m2], (extent) => {
             m2.update();
-            extent.action('inside side effect', () => {
+            extent.action(() => {
                 eventLoopOrder = effectCounter++;
             });
         });
@@ -1336,7 +1339,7 @@ describe('Effects, Actions, Events', () => {
         let m1 = ext.moment('m1');
         let m2 = ext.moment('m2');
         ext.behavior([m1], [m2], (extent) => {
-            extent.action('inside side effect', () => {
+            extent.action(() => {
                 // this will force event to finish when it runs synchronously
             });
             // event should have finished by the time we return up the stack
@@ -1350,6 +1353,7 @@ describe('Effects, Actions, Events', () => {
         m1.updateWithAction();
 
     });
+     */
 
     test('actions are run synchronously by default when there is only one', () => {
         // |> Given there are no running events
@@ -1357,7 +1361,7 @@ describe('Effects, Actions, Events', () => {
         ext.addToGraphWithAction();
 
         // |> When an action is added
-        ext.action('action', () => {
+        ext.action(() => {
             counter = counter + 1;
         });
 
@@ -1373,15 +1377,15 @@ describe('Effects, Actions, Events', () => {
         ext.addToGraphWithAction();
 
         // |> When a new action is added
-        ext.action('existing', () => {
-            ext.sideEffect('side effect', (extent) => {
-                ext.action('new', () => {
+        ext.action(() => {
+            ext.sideEffect((extent) => {
+                ext.action(() => {
                     actionIsRun = counter;
                     counter = counter + 1;
                 });
                 effectIsRun = counter;
                 counter = counter + 1;
-            });
+            }, 'side effect');
         });
 
         // |> Then it will be run after first event completes entirely
@@ -1397,15 +1401,15 @@ describe('Effects, Actions, Events', () => {
         ext.addToGraphWithAction();
 
         // |> When a new action is added asynchronously
-        ext.action('existing', () => {
-            ext.sideEffect('side effect', (extent) => {
-                ext.actionAsync('new', () => {
+        ext.action(() => {
+            ext.sideEffect((extent) => {
+                ext.actionAsync(() => {
                     actionIsRun = counter;
                     counter = counter + 1;
                 });
                 effectIsRun = counter;
                 counter = counter + 1;
-            });
+            }, 'side effect');
         });
 
         // |> Then it will be run after first event completes entirely
@@ -1416,10 +1420,10 @@ describe('Effects, Actions, Events', () => {
     test('actionAsync runs immediately if no current events', () => {
         let effectIsRun = false;
         ext.addToGraphWithAction();
-        ext.actionAsync('existing', () => {
-            ext.sideEffect('side effect', (extent) => {
+        ext.actionAsync(() => {
+            ext.sideEffect((extent) => {
                 effectIsRun = true;
-            });
+            }, 'side effect');
         });
 
         expect(effectIsRun).toBeTruthy();
@@ -1443,10 +1447,178 @@ describe('Effects, Actions, Events', () => {
     test('effects can only be run during an event', () => {
         ext.addToGraphWithAction();
         expect(() => {
-            ext.sideEffect('should throw', (extent) => {
+            ext.sideEffect((extent) => {
                 // do nothing
+            }, 'should throw');
+        }).toThrow();
+    });
+
+    test('actions have knowledge of changes for debugging', () => {
+        // |> Given a subsequent behavior
+        let m1 = ext.moment('m1')
+        let m2 = ext.moment('m2')
+        let m3 = ext.moment('m3')
+
+        let actionUpdatesDuring;
+        ext.behavior([m1], [m3], extent => {
+            m3.update()
+            actionUpdatesDuring = extent.graph.eventLoopState?.actionUpdates;
+        });
+        ext.addToGraphWithAction();
+
+        // |> When action updates multiple resources
+        g.action(() => {
+            m1.update();
+            m2.update();
+        });
+
+        // |> Then that information is available during the current event
+        expect(actionUpdatesDuring).toStrictEqual([m1, m2]);
+        expect(g.eventLoopState?.actionUpdates).toBeUndefined();
+    });
+
+    test('actions have debugName', () => {
+        let m1 = ext.moment();
+        let s1 = ext.state<number>(1);
+        let lastActionName;
+        ext.behavior([ext.added, m1, s1], null, extent => {
+            lastActionName = extent.graph.eventLoopState?.action.debugName;
+        });
+        ext.addToGraphWithAction('added');
+        expect(lastActionName).toBe('added');
+
+        g.action(() => {
+            m1.update();
+        }, '1');
+
+        expect(lastActionName).toBe('1');
+
+        g.actionAsync(() => {
+            m1.update();
+        }, '2');
+
+        expect(lastActionName).toBe('2');
+
+        m1.updateWithAction(undefined,'3');
+
+        expect(lastActionName).toBe('3');
+
+        s1.updateWithAction(2, '4');
+
+        expect(lastActionName).toBe('4');
+
+        ext.action(() => {
+            m1.update();
+        }, '5');
+
+        expect(lastActionName).toBe('5');
+
+        ext.actionAsync(() => {
+            m1.update();
+        }, '6');
+
+        expect(lastActionName).toBe('6');
+    });
+
+    test('sideEffects have debugName', () => {
+        let m1 = ext.moment();
+        let m2 = ext.moment();
+        let firstSideEffectName;
+        let secondSideEffectName;
+        ext.behavior([m1], [m2], extent => {
+            m2.update();
+            extent.sideEffect(extent1 => {
+                firstSideEffectName = extent.graph.eventLoopState?.currentSideEffect?.debugName;
+            }, '1');
+        });
+        ext.behavior([m2], null, extent => {
+            extent.sideEffect(extent1 => {
+                secondSideEffectName = extent.graph.eventLoopState?.currentSideEffect?.debugName;
+            });
+        });
+        ext.addToGraphWithAction();
+        m1.updateWithAction();
+
+        expect(firstSideEffectName).toBe('1');
+        expect(secondSideEffectName).toBeUndefined();
+    });
+
+    test('can create side effects with graph object', () => {
+        let valueAfter = 0;
+        let sideEffectName;
+        g.action(() => {
+            g.sideEffect(() => {
+                valueAfter = 1;
+                sideEffectName = g.eventLoopState?.currentSideEffect?.debugName;
+            }, 'sideEffect1');
+        });
+        expect(valueAfter).toBe(1);
+        expect(sideEffectName).toBe('sideEffect1');
+    });
+
+    test('defining behavior visible inside side effect', () => {
+        let m1 = ext.moment();
+        let definingBehavior;
+        let createdBehavior = ext.behavior([m1], null, ext => {
+            ext.sideEffect(extent => {
+                definingBehavior = extent.graph.eventLoopState!.currentSideEffect!.behavior;
+            });
+        });
+
+        ext.addToGraphWithAction();
+        m1.updateWithAction();
+
+        expect(definingBehavior).toBe(createdBehavior);
+    });
+
+    test('action inside sideEffect has extent', () => {
+        let m1 = ext.moment();
+        let insideExtent;
+        ext.behavior([m1], null, ext => {
+            ext.sideEffect(extent => {
+                extent.action(extent1 => {
+                    insideExtent = extent1;
+                });
+            });
+        });
+        ext.addToGraphWithAction();
+        m1.updateWithAction();
+
+        expect(insideExtent).toBe(ext);
+    });
+
+    test('nested actions are disallowed', () => {
+        expect(() => {
+            g.action(() => {
+                g.action(() => {
+
+                });
             });
         }).toThrow();
     });
+
+    test('actions directly inside behaviors are disallowed', () => {
+        ext.behavior([ext.added], null, extent => {
+            extent.action(extent => {
+               // throws
+            });
+        });
+
+        expect(() => {
+            ext.addToGraphWithAction();
+        }).toThrow();
+    });
+
+    test('sideEffect in sideEffect doesnt make sense', () => {
+        expect(() => {
+            g.action(() => {
+                g.sideEffect(() => {
+                    g.sideEffect(() => {
+                        // throws
+                    });
+                });
+            });
+        }).toThrow();
+    })
 });
 

--- a/src/__tests__/bggraph.test.ts
+++ b/src/__tests__/bggraph.test.ts
@@ -448,8 +448,10 @@ describe('Moment Resource', () => {
         // Given a moment with data
         let mr1 = new Moment<number>(ext, 'mr1');
         let afterUpdate: unknown;
+        let updatedToOne = false;
         ext.behavior([mr1], null, (extent) => {
             afterUpdate = mr1.value;
+            updatedToOne = mr1.justUpdatedTo(1);
         });
         ext.addToGraphWithAction();
 
@@ -458,7 +460,8 @@ describe('Moment Resource', () => {
 
         // |> Then the data is visible in subsequent behaviors
         expect(afterUpdate).toBe(1);
-
+        expect(updatedToOne).toBeTruthy();
+        
         // but is transient outside event
         expect(mr1.value).toBeUndefined();
     });

--- a/src/__tests__/bggraph.test.ts
+++ b/src/__tests__/bggraph.test.ts
@@ -336,9 +336,78 @@ describe('State Resource', () => {
             }).toThrow();
 
         });
+
+        test('cannot access value inside behavior if not supply or demand', () => {
+            let sr1 = ext.state(1);
+            let sr2 = ext.state(1);
+            let sr3 = ext.state(1);
+            let sr4 = ext.state(1);
+            let sr5 = ext.state(1);
+
+            // |> Given resource that are supplied and demanded
+            ext.behavior([sr1], [sr2], ext => {
+                sr1.value;
+                sr1.event;
+                sr1.justUpdated;
+                sr2.value;
+                sr2.event;
+                sr2.justUpdated;
+            });
+            ext.addToGraphWithAction();
+
+            // |> When they are accessed inside a behavior during an event
+            // |> Then it will succeed
+            sr1.updateWithAction(2);
+
+            // |> And when they are accessed outside an event or behavior
+            // |> Then it will succeed
+            sr1.value;
+            sr1.event;
+            sr1.justUpdated;
+
+            // |> And when we access a non-supplied resource inside an action
+            // |> Then it will succeed
+            g.action(() => {
+                sr1.value;
+            });
+
+            // |> But Given behaviors that access value, event, or justUpdated for a resource
+            // that is not supplied or demanded
+            let ext2 = new Extent(g);
+            ext2.behavior([sr3], null, ext => {
+                sr2.value;
+            });
+
+            ext2.behavior([sr4], null, ext => {
+                sr2.event;
+            });
+
+            ext2.behavior([sr5], null, ext => {
+                sr2.justUpdated;
+            });
+            ext2.addToGraphWithAction();
+
+            // |> Then it will fail
+            expect(() => {
+                sr3.updateWithAction(2);
+            }).toThrow();
+
+            expect(() => {
+                sr4.updateWithAction(2);
+            }).toThrow();
+
+            expect(() => {
+                sr5.updateWithAction(2);
+            }).toThrow();
+
+            // |> And when we access a supplied resource from an action
+            // |> Then it will fail
+            expect(() => {
+                sr2.updateWithAction(2);
+            }).toThrow();
+        });
     });
-})
-;
+});
 
 describe('Moment Resource', () => {
 
@@ -463,6 +532,76 @@ describe('Moment Resource', () => {
             ext.addToGraphWithAction();
             expect(() => {
                 mr1.update();
+            }).toThrow();
+        });
+
+        test('cannot access value inside behavior if not supply or demand', () => {
+            let mr1 = ext.moment();
+            let mr2 = ext.moment();
+            let mr3 = ext.moment();
+            let mr4 = ext.moment();
+            let mr5 = ext.moment();
+
+            // |> Given resource that are supplied and demanded
+            ext.behavior([mr1], [mr2], ext => {
+                mr1.value;
+                mr1.event;
+                mr1.justUpdated;
+                mr2.value;
+                mr2.event;
+                mr2.justUpdated;
+            });
+            ext.addToGraphWithAction();
+
+            // |> When they are accessed inside a behavior during an event
+            // |> Then it will succeed
+            mr1.updateWithAction();
+
+            // |> And when they are accessed outside an event or behavior
+            // |> Then it will succeed
+            mr1.value;
+            mr1.event;
+            mr1.justUpdated;
+
+            // |> And when we access a non-supplied resource inside an action
+            // |> Then it will succeed
+            g.action(() => {
+                mr1.value;
+            });
+
+            // |> But Given behaviors that access value, event, or justUpdated for a resource
+            // that is not supplied or demanded
+            let ext2 = new Extent(g);
+            ext2.behavior([mr3], null, ext => {
+                mr2.value;
+            });
+
+            ext2.behavior([mr4], null, ext => {
+                mr2.event;
+            });
+
+            ext2.behavior([mr5], null, ext => {
+                mr2.justUpdated;
+            });
+            ext2.addToGraphWithAction();
+
+            // |> Then it will fail
+            expect(() => {
+                mr3.updateWithAction();
+            }).toThrow();
+
+            expect(() => {
+                mr4.updateWithAction();
+            }).toThrow();
+
+            expect(() => {
+                mr5.updateWithAction();
+            }).toThrow();
+
+            // |> And when we access a supplied resource from an action
+            // |> Then it will fail
+            expect(() => {
+                mr2.updateWithAction();
             }).toThrow();
         });
 

--- a/src/__tests__/bggraph.test.ts
+++ b/src/__tests__/bggraph.test.ts
@@ -647,6 +647,21 @@ describe('dependencies', () => {
         expect(r_a.subsequents!.size).toBe(1);
     });
 
+    test('ordering resources arent called', () => {
+        // |> Given a behavior with an ordering demand
+        let run = false;
+        ext.behavior([r_a, r_b.order], null, ext1 => {
+            run = true;
+        });
+        ext.addToGraphWithAction();
+
+        // |> When that demand is updated
+        r_b.updateWithAction(1);
+
+        // |> Then that behavior doesn't run
+        expect(run).toBeFalsy();
+    });
+
     test('check can update resource in a different extent', () => {
 
         let parentExt = new Extent(g)
@@ -1571,7 +1586,7 @@ describe('Effects, Actions, Events', () => {
             });
         }).then(() => {
             order.push(4);
-            expect(order).toStrictEqual([1,2,3,4]);
+            expect(order).toStrictEqual([1, 2, 3, 4]);
         });
         order.push(3);
         return p;
@@ -1592,7 +1607,7 @@ describe('Effects, Actions, Events', () => {
             });
         }).then(() => {
             order.push(4);
-            expect(order).toStrictEqual([1,2,3,4]);
+            expect(order).toStrictEqual([1, 2, 3, 4]);
         });
         order.push(3);
         return p;

--- a/src/__tests__/vending.test.ts
+++ b/src/__tests__/vending.test.ts
@@ -19,13 +19,11 @@ describe('Version 1: Simple Vending Machine', () => {
 
     class VendingMachine extends Extent {
         sodasVended: number = 0;
-        buttonAction: Moment = new Moment(this);
-        vendEffect: Behavior = this.makeBehavior([this.buttonAction], [], (extent: VendingMachine) => {
-            if (extent.buttonAction.justUpdated) {
-                extent.sideEffect('vend', (extent) => {
-                    extent.sodasVended += 1;
-                });
-            }
+        buttonAction: Moment = this.moment();
+        vendEffect: Behavior = this.behavior([this.buttonAction], [], (extent: VendingMachine) => {
+            extent.sideEffect('vend', (extent) => {
+                extent.sodasVended += 1;
+            });
         });
     }
 
@@ -47,11 +45,11 @@ describe('Version 2: No Free Soda', () => {
         SODA_PRICE: number = 100;
         sodasVended: number = 0;
 
-        buttonAction: Moment = new Moment(this);
-        insertCoinsAction: Moment<number> = new Moment(this);
-        coinsTotal: State<number> = new State(this, 0);
+        buttonAction: Moment = this.moment();
+        insertCoinsAction: Moment<number> = this.moment();
+        coinsTotal: State<number> = this.state(0);
 
-        vendEffect: Behavior = this.makeBehavior([this.buttonAction, this.insertCoinsAction], [this.coinsTotal], extent => {
+        vendEffect: Behavior = this.behavior([this.buttonAction, this.insertCoinsAction], [this.coinsTotal], extent => {
 
             let coins = extent.coinsTotal.value;
 
@@ -68,7 +66,7 @@ describe('Version 2: No Free Soda', () => {
                 }
             }
 
-            extent.coinsTotal.update(coins, true);
+            extent.coinsTotal.update(coins);
 
         });
     }
@@ -122,14 +120,14 @@ describe('Version 3: Cans', () => {
         cansDisplay: number = 0;
         coinsDisplay: number = 0;
 
-        buttonAction: Moment = new Moment(this);
-        insertCoinsAction: Moment<number> = new Moment(this);
-        restockAction: Moment<number> = new Moment(this);
+        buttonAction: Moment = this.moment();
+        insertCoinsAction: Moment<number> = this.moment();
+        restockAction: Moment<number> = this.moment();
 
-        coinsTotal: State<number> = new State(this, 0);
-        cansTotal: State<number> = new State(this, 0);
+        coinsTotal: State<number> = this.state(0);
+        cansTotal: State<number> = this.state(0);
 
-        vendEffect: Behavior = this.makeBehavior([this.buttonAction, this.insertCoinsAction, this.restockAction],
+        vendEffect: Behavior = this.behavior([this.buttonAction, this.insertCoinsAction, this.restockAction],
             [this.coinsTotal, this.cansTotal], extent => {
 
             let coins = extent.coinsTotal.value;
@@ -150,22 +148,22 @@ describe('Version 3: Cans', () => {
                     })
                 }
             }
-            extent.coinsTotal.update(coins, true);
-            extent.cansTotal.update(cans, true);
+            extent.coinsTotal.update(coins);
+            extent.cansTotal.update(cans);
         });
 
         constructor(graph: Graph) {
             super(graph);
 
-            this.makeBehavior([this.coinsTotal], null, extent => {
+            this.behavior([this.coinsTotal], null, extent => {
                 extent.sideEffect('coin display',(extent) => {
-                    extent.coinsDisplay = this.coinsTotal.value;
+                    extent.coinsDisplay = extent.coinsTotal.value;
                 });
             });
 
-            this.makeBehavior([this.cansTotal], null, extent => {
+            this.behavior([this.cansTotal], null, extent => {
                 extent.sideEffect('can display', (extent) => {
-                    extent.cansDisplay = this.cansTotal.value;
+                    extent.cansDisplay = extent.cansTotal.value;
                 });
             });
 
@@ -209,31 +207,31 @@ describe('Version 4: Vending State', () => {
         cansDisplay: number = 0;
         coinsDisplay: number = 0;
 
-        buttonAction: Moment = new Moment(this);
-        insertCoinsAction: Moment<number> = new Moment(this);
-        restockAction: Moment<number> = new Moment(this);
-        vending: State<boolean> = new State(this, false);
-        completeVendAction: Moment = new Moment(this);
+        buttonAction: Moment = this.moment();
+        insertCoinsAction: Moment<number> = this.moment();
+        restockAction: Moment<number> = this.moment();
+        vending: State<boolean> = this.state(false);
+        completeVendAction: Moment = this.moment();
 
-        coinsTotal: State<number> = new State(this, 0);
-        cansTotal: State<number> = new State(this, 0);
+        coinsTotal: State<number> = this.state(0);
+        cansTotal: State<number> = this.state(0);
 
         constructor(graph: Graph) {
             super(graph);
 
-            this.makeBehavior([this.coinsTotal], null, extent => {
+            this.behavior([this.coinsTotal], null, extent => {
                 extent.sideEffect('coin display', (extent) => {
                     extent.coinsDisplay = extent.coinsTotal.value;
                 });
             });
 
-            this.makeBehavior([this.cansTotal], null, extent => {
+            this.behavior([this.cansTotal], null, extent => {
                 extent.sideEffect('can display', (extent) => {
                     extent.cansDisplay = extent.cansTotal.value;
                 });
             });
 
-            this.makeBehavior(
+            this.behavior(
                 [this.completeVendAction, this.insertCoinsAction, this.restockAction],
                 [this.coinsTotal, this.cansTotal],
                 extent => {
@@ -249,12 +247,12 @@ describe('Version 4: Vending State', () => {
                         cans -= 1;
                     }
 
-                    extent.coinsTotal.update(coins, true);
-                    extent.cansTotal.update(cans, true);
+                    extent.coinsTotal.update(coins);
+                    extent.cansTotal.update(cans);
 
                 });
 
-            this.makeBehavior(
+            this.behavior(
                 [this.coinsTotal, this.cansTotal, this.buttonAction, this.completeVendAction],
                 [this.vending],
                 (extent) => {
@@ -265,7 +263,7 @@ describe('Version 4: Vending State', () => {
                     // given extent.vending.value
                     if (extent.vending.value) {
                         if (extent.completeVendAction.justUpdated) {
-                            extent.vending.update(false, true);
+                            extent.vending.update(false);
                         }
                     } else {
                         if (extent.buttonAction.justUpdated) {
@@ -273,7 +271,7 @@ describe('Version 4: Vending State', () => {
                                 extent.sideEffect('vend', (extent) => {
                                     extent.sodasVended += 1;
                                 });
-                                extent.vending.update(true, true);
+                                extent.vending.update(true);
                             }
                         }
                     }
@@ -344,35 +342,35 @@ describe('Version 5: Jammed', () => {
         coinsReturned: number = 0;
 
         // measures
-        buttonAction: Moment = new Moment(this);
-        insertCoinsAction: Moment<number> = new Moment(this);
-        restockAction: Moment<number> = new Moment(this);
-        completeVendAction: Moment = new Moment(this);
-        timeoutAction: Moment = new Moment(this);
-        fixJamAction: Moment = new Moment(this);
+        buttonAction: Moment = this.moment();
+        insertCoinsAction: Moment<number> = this.moment();
+        restockAction: Moment<number> = this.moment();
+        completeVendAction: Moment = this.moment();
+        timeoutAction: Moment = this.moment();
+        fixJamAction: Moment = this.moment();
 
         // resources
-        vending: State<boolean> = new State(this, false);
-        coinsTotal: State<number> = new State(this, 0);
-        cansTotal: State<number> = new State(this, 0);
-        jammed: State<boolean> = new State(this, false);
+        vending: State<boolean> = this.state(false);
+        coinsTotal: State<number> = this.state(0);
+        cansTotal: State<number> = this.state(0);
+        jammed: State<boolean> = this.state(false);
 
         constructor(graph: Graph) {
             super(graph);
 
-            this.makeBehavior([this.coinsTotal], null, extent => {
+            this.behavior([this.coinsTotal], null, extent => {
                 extent.sideEffect('coin display', (extent) => {
                     extent.coinsDisplay = extent.coinsTotal.value;
                 });
             });
 
-            this.makeBehavior([this.cansTotal], null, extent => {
+            this.behavior([this.cansTotal], null, extent => {
                 extent.sideEffect('can display', () => {
                     extent.cansDisplay = extent.cansTotal.value
                 });
             });
 
-            this.makeBehavior(
+            this.behavior(
                 [this.completeVendAction, this.insertCoinsAction, this.restockAction],
                 [this.coinsTotal, this.cansTotal],
                 extent => {
@@ -400,12 +398,12 @@ describe('Version 5: Jammed', () => {
                         cans -= 1;
                     }
 
-                    extent.coinsTotal.update(coins, true);
-                    extent.cansTotal.update(cans, true);
+                    extent.coinsTotal.update(coins);
+                    extent.cansTotal.update(cans);
 
                 });
 
-            this.makeBehavior(
+            this.behavior(
                 [this.coinsTotal, this.cansTotal, this.buttonAction, this.completeVendAction, this.jammed],
                 [this.vending],
                 (extent) => {
@@ -416,21 +414,21 @@ describe('Version 5: Jammed', () => {
 
                     if (vending) {
                         if (extent.completeVendAction.justUpdated) {
-                            extent.vending.update(false, true);
+                            extent.vending.update(false);
                         } else if (extent.jammed.justUpdatedTo(true)) {
-                            extent.vending.update(false, true);
+                            extent.vending.update(false);
                         }
                     } else {
                         if (extent.buttonAction.justUpdated) {
                             if (coins >= extent.SODA_PRICE && cans > 0) {
-                                extent.vending.update(true, true);
+                                extent.vending.update(true);
                             }
                         }
                     }
 
                 });
 
-            this.makeBehavior([this.vending], null, (extent) => {
+            this.behavior([this.vending], null, (extent) => {
                 if (extent.vending.justUpdatedTo(true)) {
                     extent.sideEffect('vend, start timeout timer',(extent) => {
                         extent.vendTimeoutTimerRunning = true;
@@ -443,15 +441,15 @@ describe('Version 5: Jammed', () => {
                 }
             });
 
-            this.makeBehavior(
+            this.behavior(
                 [this.timeoutAction, this.fixJamAction],
                 [this.jammed],
                 (extent) => {
                     // if we started vending
                     if (extent.vending.traceValue && extent.timeoutAction.justUpdated) {
-                        extent.jammed.update(true, true);
+                        extent.jammed.update(true);
                     } else if (extent.jammed.value && extent.fixJamAction.justUpdated) {
-                        extent.jammed.update(false, true);
+                        extent.jammed.update(false);
                     }
                 }
             )

--- a/src/__tests__/vending.test.ts
+++ b/src/__tests__/vending.test.ts
@@ -3,17 +3,7 @@
 //
 
 
-import { 
-    Graph, 
-    GraphEvent, 
-    BehaviorGraphDateProvider,
-    Behavior,
-    State,
-    Moment,
-    Resource,
-    Extent,
-    InitialEvent
- } from '../index';
+import {Behavior, Extent, Graph, InitialEvent, Moment, State} from '../index';
 
 describe('Version 1: Simple Vending Machine', () => {
 
@@ -21,9 +11,9 @@ describe('Version 1: Simple Vending Machine', () => {
         sodasVended: number = 0;
         buttonAction: Moment = this.moment();
         vendEffect: Behavior = this.behavior([this.buttonAction], [], (extent: VendingMachine) => {
-            extent.sideEffect('vend', (extent) => {
+            extent.sideEffect((extent) => {
                 extent.sodasVended += 1;
-            });
+            }, 'vend');
         });
     }
 
@@ -60,9 +50,9 @@ describe('Version 2: No Free Soda', () => {
             if (extent.buttonAction.justUpdated) {
                 if (coins >= extent.SODA_PRICE) {
                     coins -= extent.SODA_PRICE;
-                    extent.sideEffect('vend', (extent) => {
+                    extent.sideEffect((extent) => {
                         extent.sodasVended += 1;
-                    });
+                    }, 'vend');
                 }
             }
 
@@ -143,9 +133,9 @@ describe('Version 3: Cans', () => {
                 if (coins >= extent.SODA_PRICE && cans > 0) {
                     coins -= extent.SODA_PRICE;
                     cans -= 1;
-                    extent.sideEffect('vend',(extent) => {
+                    extent.sideEffect((extent) => {
                         extent.sodasVended += 1;
-                    })
+                    }, 'vend')
                 }
             }
             extent.coinsTotal.update(coins);
@@ -156,15 +146,15 @@ describe('Version 3: Cans', () => {
             super(graph);
 
             this.behavior([this.coinsTotal], null, extent => {
-                extent.sideEffect('coin display',(extent) => {
+                extent.sideEffect((extent) => {
                     extent.coinsDisplay = extent.coinsTotal.value;
-                });
+                }, 'coin display');
             });
 
             this.behavior([this.cansTotal], null, extent => {
-                extent.sideEffect('can display', (extent) => {
+                extent.sideEffect((extent) => {
                     extent.cansDisplay = extent.cansTotal.value;
-                });
+                }, 'can display');
             });
 
         }
@@ -220,15 +210,15 @@ describe('Version 4: Vending State', () => {
             super(graph);
 
             this.behavior([this.coinsTotal], null, extent => {
-                extent.sideEffect('coin display', (extent) => {
+                extent.sideEffect((extent) => {
                     extent.coinsDisplay = extent.coinsTotal.value;
-                });
+                }, 'coin display');
             });
 
             this.behavior([this.cansTotal], null, extent => {
-                extent.sideEffect('can display', (extent) => {
+                extent.sideEffect((extent) => {
                     extent.cansDisplay = extent.cansTotal.value;
-                });
+                }, 'can display');
             });
 
             this.behavior(
@@ -268,9 +258,9 @@ describe('Version 4: Vending State', () => {
                     } else {
                         if (extent.buttonAction.justUpdated) {
                             if (coins >= extent.SODA_PRICE && cans > 0) {
-                                extent.sideEffect('vend', (extent) => {
+                                extent.sideEffect((extent) => {
                                     extent.sodasVended += 1;
-                                });
+                                }, 'vend');
                                 extent.vending.update(true);
                             }
                         }
@@ -359,15 +349,15 @@ describe('Version 5: Jammed', () => {
             super(graph);
 
             this.behavior([this.coinsTotal], null, extent => {
-                extent.sideEffect('coin display', (extent) => {
+                extent.sideEffect((extent) => {
                     extent.coinsDisplay = extent.coinsTotal.value;
-                });
+                }, 'coin display');
             });
 
             this.behavior([this.cansTotal], null, extent => {
-                extent.sideEffect('can display', () => {
+                extent.sideEffect(() => {
                     extent.cansDisplay = extent.cansTotal.value
-                });
+                }, 'can display');
             });
 
             this.behavior(
@@ -381,9 +371,9 @@ describe('Version 5: Jammed', () => {
                     if (extent.insertCoinsAction.justUpdated) {
                         let inserted = extent.insertCoinsAction.value!;
                         if (extent.jammed.traceValue) {
-                            extent.sideEffect('return coins', (extent) => {
+                            extent.sideEffect((extent) => {
                                 extent.coinsReturned = inserted;
-                            });
+                            }, 'return coins');
                         } else {
                             coins += inserted;
                         }
@@ -430,14 +420,14 @@ describe('Version 5: Jammed', () => {
 
             this.behavior([this.vending], null, (extent) => {
                 if (extent.vending.justUpdatedTo(true)) {
-                    extent.sideEffect('vend, start timeout timer',(extent) => {
+                    extent.sideEffect((extent) => {
                         extent.vendTimeoutTimerRunning = true;
                         extent.sodasVended += 1;
-                    });
+                    }, 'vend, start timeout timer');
                 } else if (extent.vending.justUpdatedTo(false)) {
-                    extent.sideEffect('stop, timeout timer',(extent) => {
+                    extent.sideEffect((extent) => {
                         extent.vendTimeoutTimerRunning = false;
-                    });
+                    }, 'stop, timeout timer');
                 }
             });
 

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -48,24 +48,6 @@ export class Behavior implements Orderable {
 
 }
 
-export class DynamicDemands<T extends Extent> {
-    switches: Demandable[];
-    links: (ext: T) => Demandable[] | null
-    constructor(switches: Demandable[], links: (ext: T) => Demandable[] | null) {
-        this.switches = switches;
-        this.links = links;
-    }
-}
-
-export class DynamicSupplies<T extends Extent> {
-    switches: Demandable[];
-    links: (ext: T) => Resource[] | null
-    constructor(switches: Demandable[], links: (ext: T) => Resource[] | null) {
-        this.switches = switches;
-        this.links = links;
-    }
-}
-
 export class BehaviorBuilder<T extends Extent> {
     extent: T;
     untrackedDemands: Demandable[] | null = null;

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -5,7 +5,7 @@
 
 import {Orderable} from "./bufferedqueue";
 import {Extent} from "./extent";
-import {Resource, Linkable} from "./resource";
+import {Resource, Demandable} from "./resource";
 import {OrderingState} from "./bggraph"
 
 export class Behavior implements Orderable {
@@ -20,10 +20,10 @@ export class Behavior implements Orderable {
     orderingState: OrderingState = OrderingState.Untracked;
     order: number = 0;
 
-    untrackedDemands: Linkable[] | null;
+    untrackedDemands: Demandable[] | null;
     untrackedSupplies: Resource[] | null;
 
-    constructor(extent: Extent, demands: Linkable[] | null, supplies: Resource[] | null, block: (extent: Extent) => void) {
+    constructor(extent: Extent, demands: Demandable[] | null, supplies: Resource[] | null, block: (extent: Extent) => void) {
         this.extent = extent;
         extent.addBehavior(this);
         this.demands = null;
@@ -34,11 +34,100 @@ export class Behavior implements Orderable {
         this.untrackedSupplies = supplies;
     }
 
-    setDemands(newDemands: Resource[]) {
+    setDemands(newDemands: Demandable[]) {
         this.extent.graph.updateDemands(this, newDemands);
     }
 
     setSupplies(newSupplies: Resource[]) {
         this.extent.graph.updateSupplies(this, newSupplies);
+    }
+
+}
+
+export class DynamicDemands<T extends Extent> {
+    switches: Demandable[];
+    links: (ext: T) => Demandable[] | null
+    constructor(switches: Demandable[], links: (ext: T) => Demandable[] | null) {
+        this.switches = switches;
+        this.links = links;
+    }
+}
+
+export class DynamicSupplies<T extends Extent> {
+    switches: Demandable[];
+    links: (ext: T) => Resource[] | null
+    constructor(switches: Demandable[], links: (ext: T) => Resource[] | null) {
+        this.switches = switches;
+        this.links = links;
+    }
+}
+
+export class BehaviorBuilder<T extends Extent> {
+    extent: T;
+    untrackedDemands: Demandable[] | null = null;
+    untrackedSupplies: Resource[] | null = null;
+    dynamicDemandSwitches: Demandable[] | null = null;
+    dynamicDemandLinks: ((ext: T) => Demandable[] | null) | null = null;
+    dynamicSupplySwitches: Demandable[] | null = null;
+    dynamicSupplyLinks: ((ext: T) => Resource[] | null) | null = null;
+
+    constructor(extent: T) {
+        this.extent = extent;
+    }
+
+    demands(...demands: Demandable[]): this {
+        this.untrackedDemands = demands;
+        return this;
+    }
+
+    supplies(...supplies: Resource[]): this {
+        this.untrackedSupplies = supplies;
+        return this;
+    }
+
+    dynamicDemands(switches: Demandable[], links: ((ext: T) => Demandable[] | null)): this {
+        this.dynamicDemandSwitches = switches;
+        this.dynamicDemandLinks = links;
+        return this;
+    }
+
+    dynamicSupplies(switches: Demandable[], links: ((ext: T) => Resource[] | null)): this {
+        this.dynamicSupplySwitches = switches;
+        this.dynamicSupplyLinks = links;
+        return this;
+    }
+
+    runs(block: (ext: T) => void): Behavior {
+        let hasDynamicDemands = this.dynamicDemandSwitches != null;
+        let dynamicDemandResource: Resource;
+        if (hasDynamicDemands) {
+            dynamicDemandResource = this.extent.resource('(BG Dynamic Demand Resource)')
+            this.untrackedDemands?.push(dynamicDemandResource);
+        }
+
+        let hasDynamicSupplies = this.dynamicSupplySwitches != null;
+        let dynamicSupplyResource: Resource;
+        if (hasDynamicSupplies) {
+            dynamicSupplyResource = this.extent.resource('(BG Dynamic Supply Resource)');
+            this.untrackedDemands?.push(dynamicSupplyResource);
+        }
+
+        let mainBehavior = new Behavior(this.extent, this.untrackedDemands, this.untrackedSupplies, block as (arg0: Extent) => void);
+
+        if (hasDynamicDemands) {
+            new Behavior(this.extent, this.dynamicDemandSwitches, [dynamicDemandResource!], ((extent: T) => {
+               let demandLinks = this.dynamicDemandLinks!(extent);
+               mainBehavior.setDemands([...(this.untrackedDemands ?? []), ...(demandLinks ?? [])]);
+            }) as (arg0: Extent) => void);
+        }
+
+        if (hasDynamicSupplies) {
+            new Behavior(this.extent, this.dynamicSupplySwitches, [dynamicSupplyResource!], ((extent: T) => {
+                let supplyLinks = this.dynamicSupplyLinks!(extent);
+                mainBehavior.setSupplies([...(this.untrackedSupplies ?? []), ...(supplyLinks ?? [])]);
+            }) as (arg0: Extent) => void);
+        }
+
+        return mainBehavior;
     }
 }

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -4,12 +4,13 @@
 
 
 import {Orderable} from "./bufferedqueue";
-import {Extent, Named} from "./extent";
-import {Resource} from "./resource";
+import {Extent} from "./extent";
+import {Resource, Linkable} from "./resource";
 import {OrderingState} from "./bggraph"
 
 export class Behavior implements Orderable {
     demands: Set<Resource> | null;
+    orderingDemands: Set<Resource> | null;
     supplies: Set<Resource> | null;
     block: (extent: Extent) => void;
     enqueuedWhen: number | null = null;
@@ -19,13 +20,14 @@ export class Behavior implements Orderable {
     orderingState: OrderingState = OrderingState.Untracked;
     order: number = 0;
 
-    untrackedDemands: Resource[] | null;
+    untrackedDemands: Linkable[] | null;
     untrackedSupplies: Resource[] | null;
 
-    constructor(extent: Extent, demands: Resource[] | null, supplies: Resource[] | null, block: (extent: Extent) => void) {
+    constructor(extent: Extent, demands: Linkable[] | null, supplies: Resource[] | null, block: (extent: Extent) => void) {
         this.extent = extent;
         extent.addBehavior(this);
         this.demands = null;
+        this.orderingDemands = null;
         this.supplies = null;
         this.block = block;
         this.untrackedDemands = demands;

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -21,7 +21,9 @@ export class Behavior implements Orderable {
     order: number = 0;
 
     untrackedDemands: Demandable[] | null;
+    untrackedDynamicDemands: Demandable[] | null;
     untrackedSupplies: Resource[] | null;
+    untrackedDynamicSupplies: Resource[] | null;
 
     constructor(extent: Extent, demands: Demandable[] | null, supplies: Resource[] | null, block: (extent: Extent) => void) {
         this.extent = extent;
@@ -31,14 +33,16 @@ export class Behavior implements Orderable {
         this.supplies = null;
         this.block = block;
         this.untrackedDemands = demands;
+        this.untrackedDynamicDemands = null;
         this.untrackedSupplies = supplies;
+        this.untrackedDynamicSupplies = null;
     }
 
-    setDemands(newDemands: Demandable[]) {
+    setDynamicDemands(newDemands: Demandable[] | null) {
         this.extent.graph.updateDemands(this, newDemands);
     }
 
-    setSupplies(newSupplies: Resource[]) {
+    setDynamicSupplies(newSupplies: Resource[] | null) {
         this.extent.graph.updateSupplies(this, newSupplies);
     }
 
@@ -117,14 +121,14 @@ export class BehaviorBuilder<T extends Extent> {
         if (hasDynamicDemands) {
             new Behavior(this.extent, this.dynamicDemandSwitches, [dynamicDemandResource!], ((extent: T) => {
                let demandLinks = this.dynamicDemandLinks!(extent);
-               mainBehavior.setDemands([...(this.untrackedDemands ?? []), ...(demandLinks ?? [])]);
+               mainBehavior.setDynamicDemands(demandLinks);
             }) as (arg0: Extent) => void);
         }
 
         if (hasDynamicSupplies) {
             new Behavior(this.extent, this.dynamicSupplySwitches, [dynamicSupplyResource!], ((extent: T) => {
                 let supplyLinks = this.dynamicSupplyLinks!(extent);
-                mainBehavior.setSupplies([...(this.untrackedSupplies ?? []), ...(supplyLinks ?? [])]);
+                mainBehavior.setDynamicSupplies(supplyLinks);
             }) as (arg0: Extent) => void);
         }
 

--- a/src/bggraph.ts
+++ b/src/bggraph.ts
@@ -6,7 +6,7 @@
 import {BufferedPriorityQueue} from "./bufferedqueue";
 import {Behavior} from "./behavior";
 import {Extent} from "./extent";
-import {LinkType, Resource} from "./resource";
+import {Demandable, LinkType, Resource} from "./resource";
 
 export enum OrderingState {
     Untracked, // new behaviors
@@ -476,7 +476,7 @@ export class Graph {
         this.untrackedBehaviors.push(behavior)
     }
 
-    updateDemands(behavior: Behavior, newDemands: Resource[]) {
+    updateDemands(behavior: Behavior, newDemands: Demandable[]) {
         if (!behavior.added) {
             let err: any = new Error("Behavior must belong to graph before updating demands.");
             err.behavior = behavior;

--- a/src/bggraph.ts
+++ b/src/bggraph.ts
@@ -241,31 +241,33 @@ export class Graph {
     private addUntrackedSupplies() {
         if (this.modifiedSupplyBehaviors.length > 0) {
             for (let behavior of this.modifiedSupplyBehaviors) {
-                if (behavior.untrackedSupplies != null) {
-                    if (behavior.supplies != null) {
-                        for (let existingSupply of behavior.supplies) {
-                            existingSupply.suppliedBy = null;
-                        }
-                    }
-                    behavior.supplies = new Set(behavior.untrackedSupplies);
-                    for (let newSupply of behavior.supplies) {
-                        if (newSupply.suppliedBy != null && newSupply.suppliedBy != behavior) {
-                            let err: any = new Error("Resource cannot be supplied by more than one behavior.");
-                            err.alreadySupplied = newSupply;
-                            err.desiredSupplier = behavior;
-                            throw err;
-                        }
-                        newSupply.suppliedBy = behavior;
-                    }
-                    behavior.untrackedSupplies = null;
-                    // technically this doesn't need reordering but its subsequents will
-                    // setting this to reorder will also adjust its subsequents if necessary
-                    // in the sortDFS code
-                    if (behavior.orderingState != OrderingState.NeedsOrdering) {
-                        behavior.orderingState = OrderingState.NeedsOrdering;
-                        this.needsOrdering.push(behavior);
+                let allUntrackedSupplies = [...(behavior.untrackedSupplies ?? []), ...(behavior.untrackedDynamicSupplies ?? [])];
+
+                if (behavior.supplies != null) {
+                    for (let existingSupply of behavior.supplies) {
+                        existingSupply.suppliedBy = null;
                     }
                 }
+                behavior.supplies = new Set(allUntrackedSupplies);
+                for (let newSupply of behavior.supplies) {
+                    if (newSupply.suppliedBy != null && newSupply.suppliedBy != behavior) {
+                        let err: any = new Error("Resource cannot be supplied by more than one behavior.");
+                        err.alreadySupplied = newSupply;
+                        err.desiredSupplier = behavior;
+                        throw err;
+                    }
+                    newSupply.suppliedBy = behavior;
+                }
+
+                // technically this behavior doesn't need reordering but its subsequents will
+                // if they already demand a newly supplied resource
+                // setting this to reorder will ensure its subsequents will reorder if needed
+                // in the sortDFS code
+                if (behavior.orderingState != OrderingState.NeedsOrdering) {
+                    behavior.orderingState = OrderingState.NeedsOrdering;
+                    this.needsOrdering.push(behavior);
+                }
+
             }
             this.modifiedSupplyBehaviors.length = 0;
         }
@@ -274,89 +276,87 @@ export class Graph {
     private addUntrackedDemands(sequence: number) {
         if (this.modifiedDemandBehaviors.length > 0) {
             for (let behavior of this.modifiedDemandBehaviors) {
-                if (behavior.untrackedDemands != null) {
+                let allUntrackedDemands = [...(behavior.untrackedDemands ?? []), ...(behavior.untrackedDynamicDemands ?? [])];
 
-                    let removedDemands: Resource[] | undefined;
-                    if (behavior.demands != null) {
-                        for (let demand of behavior.demands) {
-                            if (!behavior.untrackedDemands.some(linkable => linkable.resource == demand)) {
-                                if (removedDemands == undefined) {
-                                    removedDemands = [];
-                                }
-                                removedDemands.push(demand);
+                let removedDemands: Resource[] | undefined;
+                if (behavior.demands != null) {
+                    for (let demand of behavior.demands) {
+                        if (!allUntrackedDemands.some(linkable => linkable.resource == demand)) {
+                            if (removedDemands == undefined) {
+                                removedDemands = [];
+                            }
+                            removedDemands.push(demand);
+                        }
+                    }
+                }
+
+                let addedDemands: Resource[] | undefined;
+                for (let linkableDemand of allUntrackedDemands) {
+                    let untrackedDemand = linkableDemand.resource;
+                    if (!untrackedDemand.added) {
+                        let err: any = new Error("All demands must be added to the graph.");
+                        err.currentBehavior = behavior;
+                        err.untrackedDemand = untrackedDemand;
+                        throw err;
+                    }
+                    if (behavior.demands == null || !behavior.demands.has(untrackedDemand)) {
+                        if (addedDemands == undefined) {
+                            addedDemands = [];
+                        }
+                        addedDemands.push(untrackedDemand);
+                    }
+                }
+
+                let needsRunning = false;
+
+                if (removedDemands != undefined) {
+                    for (let demand of removedDemands) {
+                        demand.subsequents.delete(behavior);
+                    }
+                }
+
+                let orderBehavior = behavior.orderingState != OrderingState.Ordered;
+
+                if (addedDemands != undefined) {
+                    for (let demand of addedDemands) {
+                        demand.subsequents.add(behavior);
+                        if (demand.justUpdated) {
+                            needsRunning = true;
+                        }
+                        if (!orderBehavior) {
+                            let prior = demand.suppliedBy;
+                            if (prior != null && prior.orderingState == OrderingState.Ordered && prior.order >= behavior.order) {
+                                orderBehavior = true;
                             }
                         }
                     }
+                }
 
-                    let addedDemands: Resource[] | undefined;
-                    for (let linkableDemand of behavior.untrackedDemands) {
-                        let untrackedDemand = linkableDemand.resource;
-                        if (!untrackedDemand.added) {
-                            let err: any = new Error("All demands must be added to the graph.");
-                            err.currentBehavior = behavior;
-                            err.untrackedDemand = untrackedDemand;
-                            throw err;
-                        }
-                        if (behavior.demands == null || !behavior.demands.has(untrackedDemand)) {
-                            if (addedDemands == undefined) {
-                                addedDemands = [];
-                            }
-                            addedDemands.push(untrackedDemand);
-                        }
+                let newDemands: Set<Resource> | null = null;
+                let orderingDemands: Set<Resource> | null = null;
+                for (let linkable of allUntrackedDemands) {
+                    if (newDemands == null) {
+                        newDemands = new Set();
                     }
-
-                    let needsRunning = false;
-
-                    if (removedDemands != undefined) {
-                        for (let demand of removedDemands) {
-                            demand.subsequents.delete(behavior);
+                    newDemands.add(linkable.resource);
+                    if (linkable.type == LinkType.order) {
+                        if (orderingDemands == null) {
+                            orderingDemands = new Set();
                         }
+                        orderingDemands.add(linkable.resource);
                     }
+                }
+                behavior.demands = newDemands;
+                behavior.orderingDemands = orderingDemands;
 
-                    let orderBehavior = behavior.orderingState != OrderingState.Ordered;
-
-                    if (addedDemands != undefined) {
-                        for (let demand of addedDemands) {
-                            demand.subsequents.add(behavior);
-                            if (demand.justUpdated) {
-                                needsRunning = true;
-                            }
-                            if (!orderBehavior) {
-                                let prior = demand.suppliedBy;
-                                if (prior != null && prior.orderingState == OrderingState.Ordered && prior.order >= behavior.order) {
-                                    orderBehavior = true;
-                                }
-                            }
-                        }
+                if (orderBehavior) {
+                    if (behavior.orderingState != OrderingState.NeedsOrdering) {
+                        behavior.orderingState = OrderingState.NeedsOrdering;
+                        this.needsOrdering.push(behavior);
                     }
-
-                    let newDemands: Set<Resource> | null = null;
-                    let orderingDemands: Set<Resource> | null = null;
-                    for (let linkable of behavior.untrackedDemands) {
-                        if (newDemands == null) {
-                            newDemands = new Set();
-                        }
-                        newDemands.add(linkable.resource);
-                        if (linkable.type == LinkType.order) {
-                            if (orderingDemands == null) {
-                                orderingDemands = new Set();
-                            }
-                            orderingDemands.add(linkable.resource);
-                        }
-                    }
-                    behavior.demands = newDemands;
-                    behavior.orderingDemands = orderingDemands;
-                    behavior.untrackedDemands = null;
-
-                    if (orderBehavior) {
-                        if (behavior.orderingState != OrderingState.NeedsOrdering) {
-                            behavior.orderingState = OrderingState.NeedsOrdering;
-                            this.needsOrdering.push(behavior);
-                        }
-                    }
-                    if (needsRunning) {
-                        this.activateBehavior(behavior, sequence);
-                    }
+                }
+                if (needsRunning) {
+                    this.activateBehavior(behavior, sequence);
                 }
 
 
@@ -476,7 +476,7 @@ export class Graph {
         this.untrackedBehaviors.push(behavior)
     }
 
-    updateDemands(behavior: Behavior, newDemands: Demandable[]) {
+    updateDemands(behavior: Behavior, newDemands: Demandable[] | null) {
         if (!behavior.added) {
             let err: any = new Error("Behavior must belong to graph before updating demands.");
             err.behavior = behavior;
@@ -486,11 +486,11 @@ export class Graph {
             err.behavior = behavior;
             throw err;
         }
-        behavior.untrackedDemands = newDemands;
+        behavior.untrackedDynamicDemands = newDemands;
         this.modifiedDemandBehaviors.push(behavior);
     }
 
-    updateSupplies(behavior: Behavior, newSupplies: Resource[]) {
+    updateSupplies(behavior: Behavior, newSupplies: Resource[] | null) {
         if (!behavior.added) {
             let err: any = new Error("Behavior must belong to graph before updating supplies.");
             err.behavior = behavior;
@@ -500,7 +500,7 @@ export class Graph {
             err.behavior = behavior;
             throw err;
         }
-        behavior.untrackedSupplies = newSupplies;
+        behavior.untrackedDynamicSupplies = newSupplies;
         this.modifiedSupplyBehaviors.push(behavior);
     }
 

--- a/src/extent.ts
+++ b/src/extent.ts
@@ -5,7 +5,7 @@
 
 import {Graph} from "./bggraph";
 import {Behavior} from "./behavior";
-import {Resource, State} from "./resource";
+import {Moment, Resource, State} from "./resource";
 
 export interface Named {
     debugName: string | null;
@@ -30,7 +30,7 @@ export class Extent implements Named {
         // this hidden behavior supplies addedToGraph and gets activated independently when an
         // extent is added to the graph
         this.addedToGraph = new State<boolean>(this, false);
-        this.addedToGraphBehavior = this.makeBehavior(null, [this.addedToGraph], (extent) => {
+        this.addedToGraphBehavior = this.behavior(null, [this.addedToGraph], (extent) => {
             this.addedToGraph.update(true, true);
         });
     }
@@ -89,9 +89,21 @@ export class Extent implements Named {
         }
     }
 
-    makeBehavior(demands: Resource[] | null, supplies: Resource[] | null, block: (extent: this) => void): Behavior {
+    behavior(demands: Resource[] | null, supplies: Resource[] | null, block: (extent: this) => void): Behavior {
         let behavior = new Behavior(this, demands, supplies, block as (extent: Extent) => void);
         return behavior;
+    }
+
+    resource(name?: string): Resource {
+        return new Resource(this, name);
+    }
+
+    moment<T>(name?: string): Moment<T> {
+        return new Moment<T>(this, name);
+    }
+
+    state<T>(initialState: T, name?: string): State<T> {
+        return new State<T>(this, initialState, name);
     }
 
     sideEffect(name: string | null, block: (extent: this) => void) {

--- a/src/extent.ts
+++ b/src/extent.ts
@@ -5,7 +5,7 @@
 
 import {Graph} from "./bggraph";
 import {Behavior} from "./behavior";
-import {Moment, Resource, State} from "./resource";
+import {Moment, Resource, State, Linkable} from "./resource";
 
 export interface Named {
     debugName: string | undefined;
@@ -90,7 +90,7 @@ export class Extent implements Named {
         }
     }
 
-    behavior(demands: Resource[] | null, supplies: Resource[] | null, block: (ext: this) => void): Behavior {
+    behavior(demands: Linkable[] | null, supplies: Resource[] | null, block: (ext: this) => void): Behavior {
         let behavior = new Behavior(this, demands, supplies, block as (arg0: Extent) => void);
         return behavior;
     }

--- a/src/extent.ts
+++ b/src/extent.ts
@@ -60,7 +60,7 @@ export class Extent implements Named {
     }
 
     removeFromGraphWithAction(debugName?: string) {
-        this.graph.action(() => { this.removeFromGraph(); }, debugName);
+        this.action(() => { this.removeFromGraph(); }, debugName);
     }
 
     removeFromGraph() {
@@ -113,23 +113,11 @@ export class Extent implements Named {
         this.graph.sideEffectHelper({ debugName: debugName, block: (block as (arg0: Extent | null) => void), extent: this, behavior: this.graph.currentBehavior });
     }
 
-    actionAsync(action: (ext: this) => void, debugName?: string) {
-        if (this.addedToGraphWhen != null) {
-            this.graph.actionHelper({block: action as (arg0: Extent | null) => void, debugName: debugName, extent: this }, false)
-        } else {
-            let err: any = new Error("Action on extent requires it be added to the graph.");
-            err.extent = this;
-            throw err;
-        }
+    async actionAsync(action: (ext: this) => void, debugName?: string) {
+        return this.graph.actionAsyncHelper({block: action as (arg0: Extent | null) => void, debugName: debugName, extent: this, resolve:null })
     }
 
     action(action: (ext: this) => void, debugName?: string) {
-        if (this.addedToGraphWhen != null) {
-            this.graph.actionHelper({block: action as (arg0: Extent | null) => void, debugName: debugName, extent: this }, true)
-        } else {
-            let err: any = new Error("Action on extent requires it be added to the graph.");
-            err.extent = this;
-            throw err;
-        }
+        this.graph.actionHelper({block: action as (arg0: Extent | null) => void, debugName: debugName, extent: this, resolve: null })
     }
 }

--- a/src/extent.ts
+++ b/src/extent.ts
@@ -7,15 +7,7 @@ import {Graph} from "./bggraph";
 import {Behavior, BehaviorBuilder} from "./behavior";
 import {Moment, Resource, State, Demandable} from "./resource";
 
-export interface Named {
-    debugName: string | undefined;
-}
-
-function isNamed(arg: any): arg is Named {
-    return (arg as Named).debugName !== undefined;
-}
-
-export class Extent implements Named {
+export class Extent {
     debugConstructorName: string | undefined;
     debugName: string | undefined;
     behaviors: Behavior[] = [];
@@ -85,12 +77,9 @@ export class Extent implements Named {
         // by this Extent object and name them with corresponding keys
         for (let key in this) {
             let object = this[key];
-            if (object == null || object == undefined) {
-                continue;
-            }
-            if (isNamed(object)) {
-                if (object.debugName == null) {
-                    object.debugName = key;
+            if (object && (object as any)['isResource'] !== undefined) {
+                if ((object as any as Resource).debugName == null) {
+                    (object as any as Resource).debugName = key;
                 }
             }
         }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -4,7 +4,7 @@
 
 
 import {Behavior} from "./behavior";
-import {Extent, Named} from "./extent";
+import {Extent} from "./extent";
 import {GraphEvent, Graph, Transient, InitialEvent} from "./bggraph";
 
 export enum LinkType {
@@ -17,9 +17,9 @@ export interface Demandable {
     type: LinkType
 }
 
-export class Resource implements Named, Demandable {
-    debugName: string | undefined;
-
+export class Resource implements Demandable {
+    debugName: string | null;
+    isResource: boolean = true;
     extent: Extent;
     graph: Graph;
     added: boolean = false;
@@ -33,6 +33,8 @@ export class Resource implements Named, Demandable {
         extent.addResource(this);
         if (name !== undefined) {
             this.debugName = name;
+        } else {
+            this.debugName = null;
         }
     }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -112,6 +112,10 @@ export class Moment<T = undefined> extends Resource implements Transient {
         return this._happenedWhen;
     }
 
+    justUpdatedTo(value: T): boolean {
+        return this.justUpdated && this._happenedValue == value;
+    }
+
     updateWithAction(value: T | undefined = undefined, debugName?: string) {
         this.graph.action(() => {
             this.update(value);

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -7,7 +7,19 @@ import {Behavior} from "./behavior";
 import {Extent, Named} from "./extent";
 import {GraphEvent, Graph, Transient, InitialEvent} from "./bggraph";
 
-export class Resource implements Named {
+export enum LinkType {
+    demand,
+    supply,
+    order,
+    trace
+}
+
+export interface Linkable {
+    resource: Resource,
+    type: LinkType
+}
+
+export class Resource implements Named, Linkable {
     debugName: string | undefined;
 
     extent: Extent;
@@ -24,6 +36,18 @@ export class Resource implements Named {
         if (name !== undefined) {
             this.debugName = name;
         }
+    }
+
+    get order(): Linkable {
+        return {resource: this, type: LinkType.order }
+    }
+
+    get resource(): Resource {
+        return this;
+    }
+
+    get type(): LinkType {
+        return LinkType.demand;
     }
 
     assertValidUpdater() {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -8,7 +8,7 @@ import {Extent, Named} from "./extent";
 import {GraphEvent, Graph, Transient, InitialEvent} from "./bggraph";
 
 export class Resource implements Named {
-    debugName: string | null = null;
+    debugName: string | undefined;
 
     extent: Extent;
     graph: Graph;
@@ -72,10 +72,10 @@ export class Moment<T = undefined> extends Resource implements Transient {
         return this._happenedWhen;
     }
 
-    updateWithAction(value: T | undefined = undefined) {
-        this.graph.action(this.debugName ?? ("Impulse From update(): " + this), () => {
+    updateWithAction(value: T | undefined = undefined, debugName?: string) {
+        this.graph.action(() => {
             this.update(value);
-        });
+        }, debugName);
         return;
     }
 
@@ -105,10 +105,10 @@ export class State<T> extends Resource implements Transient {
         this.currentState = { value: initialState, event: InitialEvent };
     }
 
-    updateWithAction(newValue: T) {
-        this.graph.action(this.debugName ?? ("Impulse From updateValue(): " + this), () => {
+    updateWithAction(newValue: T, debugName?: string) {
+        this.graph.action(() => {
             this.update(newValue);
-        });
+        }, debugName);
         return;
     }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -8,18 +8,16 @@ import {Extent, Named} from "./extent";
 import {GraphEvent, Graph, Transient, InitialEvent} from "./bggraph";
 
 export enum LinkType {
-    demand,
-    supply,
+    reactive,
     order,
-    trace
 }
 
-export interface Linkable {
+export interface Demandable {
     resource: Resource,
     type: LinkType
 }
 
-export class Resource implements Named, Linkable {
+export class Resource implements Named, Demandable {
     debugName: string | undefined;
 
     extent: Extent;
@@ -38,7 +36,7 @@ export class Resource implements Named, Linkable {
         }
     }
 
-    get order(): Linkable {
+    get order(): Demandable {
         return {resource: this, type: LinkType.order }
     }
 
@@ -47,7 +45,7 @@ export class Resource implements Named, Linkable {
     }
 
     get type(): LinkType {
-        return LinkType.demand;
+        return LinkType.reactive;
     }
 
     assertValidUpdater() {


### PR DESCRIPTION
A collection of public API changes and related work:

* add justUpdatedTo() to Moment
* ordering resources don't activate demanding behavior when updated
* only can set dynamicDemands/supplies (not update statics)
* added dynamicDemands/supplies clauses
* created BehaviorBuilder api
* made actionAsync javascript style async with promise
* default behavior parameter is ext (not extent), same for side effect and action
* changed addedToGraph to added
* actions in behaviors are disallowed
* side effects inside side effects are disallowed
* action from extent has pointer to extent so we can access it from a side effect without doing a capture
* nested actions are disallowed
* side effect has pointer to defining behavior for identifying behavior during debugging
* action and sideEffect methods have optional 2nd parameter for setting debugName
* action collects list of updated resources to identify it during debugging
* fix traceValue overwriting if updateValue called twice
* add extent.moment/state/resource factory methods
* change `extent.makeBehavior` to `extent.behavior`
* remove unnecessary justUpdated checks in tests
* verify demands

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
