### PR TITLE
fix: broken imports from mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/mjs/index.js",
   "types": "lib/mjs/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./lib/mjs/index.js",
@@ -38,14 +39,20 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "rm -rf lib/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup && rollup -c rollup.config.js && echo 'Build is successful!'",
+    "build": "rm -rf lib/* && tsc -p tsconfig-mjs.json && tsc -p tsconfig-cjs.json && ./fixup && rollup -c rollup.config.js && echo 'Build is successful!'",
     "test-coverage": "jest --coverage",
     "ci-build": "npm run build",
     "ci-test": "jest --coverage --runInBand --coverageDirectory $SD_ARTIFACTS_DIR/coverage"
   },
   "jest": {
-    "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
+    "preset": "ts-jest/presets/js-with-ts-esm",
+    "globals": {
+      "ts-jest": {
+        "useESM": true
+      }
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "lib/cjs/index.js",
   "module": "lib/mjs/index.js",
   "types": "lib/mjs/index.d.ts",
-  "type": "module",
   "exports": {
     ".": {
       "import": "./lib/mjs/index.js",

--- a/src/__tests__/behavior-graph.test.ts
+++ b/src/__tests__/behavior-graph.test.ts
@@ -3,7 +3,7 @@
 //
 
 
-import {Behavior, Extent, Graph, GraphEvent, Moment, Resource, State} from '../index';
+import {Behavior, Extent, Graph, GraphEvent, Moment, Resource, State} from '../index.js';
 
 let g: Graph;
 let setupExt: Extent;

--- a/src/__tests__/bufferedqueue.test.ts
+++ b/src/__tests__/bufferedqueue.test.ts
@@ -2,7 +2,7 @@
 //  Copyright Yahoo 2021
 //
 
-import { BufferedPriorityQueue, Orderable } from "../bufferedqueue";
+import { BufferedPriorityQueue, Orderable } from "../bufferedqueue.js";
 
 class Item implements Orderable {
     order: number;

--- a/src/__tests__/docs-code-example.test.js
+++ b/src/__tests__/docs-code-example.test.js
@@ -1,4 +1,4 @@
-let {Extent, Graph} = require('../index');
+import {Extent, Graph} from '../index.js';
 
 // tag::login_enable_extent[]
 class LoginExtent extends Extent {

--- a/src/__tests__/documentation.test.js
+++ b/src/__tests__/documentation.test.js
@@ -2,7 +2,7 @@
 //  Copyright Yahoo 2021
 //
 
-let {Behavior, Extent, Graph, GraphEvent, Moment, State} = require('../index');
+import {Behavior, Extent, Graph, GraphEvent, Moment, State} from '../index.js';
 
 class Extent1 extends Extent {
     constructor(graph) {

--- a/src/__tests__/vending.test.ts
+++ b/src/__tests__/vending.test.ts
@@ -3,7 +3,7 @@
 //
 
 
-import {Behavior, Extent, Graph, GraphEvent, Moment, State} from '../index';
+import {Behavior, Extent, Graph, GraphEvent, Moment, State} from '../index.js';
 
 describe('Version 1: Simple Vending Machine', () => {
 

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -3,10 +3,10 @@
 //
 
 
-import {Orderable} from "./bufferedqueue";
-import {Extent} from "./extent";
-import {Resource, Demandable} from "./resource";
-import {OrderingState} from "./graph"
+import {Orderable} from "./bufferedqueue.js";
+import {Extent} from "./extent.js";
+import {Resource, Demandable} from "./resource.js";
+import {OrderingState} from "./graph.js"
 
 export enum RelinkingOrder {
     relinkingOrderPrior,

--- a/src/extent.ts
+++ b/src/extent.ts
@@ -3,9 +3,9 @@
 //
 
 
-import {Graph} from "./graph";
-import {Behavior, BehaviorBuilder, RelinkingOrder} from "./behavior";
-import {Moment, Resource, State, Demandable} from "./resource";
+import {Graph} from "./graph.js";
+import {Behavior, BehaviorBuilder, RelinkingOrder} from "./behavior.js";
+import {Moment, Resource, State} from "./resource.js";
 
 export enum ExtentRemoveStrategy {
     extentOnly,

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -3,10 +3,10 @@
 //
 
 
-import {BufferedPriorityQueue} from "./bufferedqueue";
-import {Behavior} from "./behavior";
-import {Extent} from "./extent";
-import {Demandable, LinkType, Resource} from "./resource";
+import {BufferedPriorityQueue} from "./bufferedqueue.js";
+import {Behavior} from "./behavior.js";
+import {Extent} from "./extent.js";
+import {Demandable, LinkType, Resource} from "./resource.js";
 
 export enum OrderingState {
     Untracked, // new behaviors

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,20 +7,20 @@ export {
     DateProvider,
     Graph,
     GraphEvent
-} from "./graph";
+} from "./graph.js";
 
 export {
     Resource,
     Moment,
     State
-} from "./resource"
+} from "./resource.js"
 
 export {
     Extent,
     ExtentRemoveStrategy
-} from "./extent"
+} from "./extent.js"
 
 export {
     Behavior,
     RelinkingOrder
-} from "./behavior"
+} from "./behavior.js"

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -3,9 +3,9 @@
 //
 
 
-import {Behavior} from "./behavior";
-import {Extent} from "./extent";
-import {GraphEvent, Graph, Transient} from "./graph";
+import {Behavior} from "./behavior.js";
+import {Extent} from "./extent.js";
+import {GraphEvent, Graph, Transient} from "./graph.js";
 
 export enum LinkType {
     reactive,

--- a/tsconfig-mjs.json
+++ b/tsconfig-mjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig-base.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"outDir": "lib/mjs",
+		"target": "esnext"
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "./tsconfig-base.json",
 	"compilerOptions": {
-		"module": "esnext",
-		"outDir": "lib/mjs",
-		"target": "esnext"
-	}
+		"allowJs": true
+	},
+	"include": ["src/*", "**/__tests__/*"]
 }


### PR DESCRIPTION
## Description

When trying to import this project I got the following error because the mjs index.js file tries to list modules like `'graph'` instead of `'graph.js'`

```
$ node index.js
internal/process/esm_loader.js:74
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/hinterlong/Desktop/dev/bg-temp-test/node_modules/behavior-graph/lib/mjs/graph' imported from /Users/hinterlong/Desktop/dev/bg-temp-test/node_modules/behavior-graph/lib/mjs/index.js
    at new NodeError (internal/errors.js:322:7)
    at finalizeResolution (internal/modules/esm/resolve.js:318:11)
    at moduleResolve (internal/modules/esm/resolve.js:776:10)
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:887:11)
    at Loader.resolve (internal/modules/esm/loader.js:89:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:242:28)
    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:76:40)
    at link (internal/modules/esm/module_job.js:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

## Changes

- update import paths to specify `<module>.js`
- Move tsconfig.json to tsconfig-mjs.json for publishing and create new tsconfig.json for development. 
- make [jest use esm](https://kulshekhar.github.io/ts-jest/docs/guides/esm-support#use-esm-presets) with a [preset](https://kulshekhar.github.io/ts-jest/docs/getting-started/presets) requiring allowJs in tsconfig.json


## License
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
